### PR TITLE
go getは非推奨になっているのでgo installに修正

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 # インストール方法
 
 ```
-go get -u github.com/greymd/mamadm
+go install github.com/greymd/mamadm@latest
 ```
 
 # 使い方


### PR DESCRIPTION
失礼します！
🪶
いきなりPR送ってごめんなさい
𓀚
`get get -u`は非推奨だったのでインストールしようとしたらエラーが出た者です
```zsh
❯ go get -u github.com/greymd/mamadm

go: go.mod file not found in current directory or any parent directory.
        'go get' is no longer supported outside a module.
        To build and install a command, use 'go install' with a version,
        like 'go install example.com/cmd@latest'
        For more information, see https://golang.org/doc/go-get-install-deprecation
        or run 'go help get' or 'go help install'.
```
💸
`go install`を使ってくれる男子を募集してます。
🏐
支援充実
𓀚
興味 ある男子ははPRからまーじしてください
🧔
締め切り間近です
🌴👏
